### PR TITLE
Public Release of the ROMS-JEDI Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ running any **`ROMS-JEDI`** application, as well as the available data assimilat
 -  Check out the **`ROMS-JEDI`** interface repository.
 
    ```
-   git clone https://github.com/JCSDA-internal/roms-jedi.git
+   git clone https://github.com/myroms/roms-jedi.git
    ```
 
    During configuration, the latest version of **`ROMS`** source code is downloaded from
@@ -30,7 +30,7 @@ running any **`ROMS-JEDI`** application, as well as the available data assimilat
 
 -  Make sure that you computer have installed the **`jedi-stack`** software for either **gfortran**
    or **ifort** containing several packages need to run the **`ROMS-JEDI`** interface. For more
-   information, please check https://github.com/JCSDA-internal/jedi-stack.
+   information, please check https://github.com/JCSDA/jedi-stack.
 
    In our computers at Rutgers University, the **`jedi-stack`** can be loaded by executing either:
 
@@ -104,7 +104,7 @@ running any **`ROMS-JEDI`** application, as well as the available data assimilat
    configure **`ROMS-JEDI`** in your computer:
 
    ```
-   git clone https://github.com/JCSDA-internal/roms-jedi.git  !> if first time in your computer
+   git clone https://github.com/myroms/roms-jedi.git          !> if first time in your computer
 
    cd roms-jedi                                               !> ROMS-JEDI interface directory, <interface_dir>
    mkdir Bundle_wc13

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ROMS interface to JEDI
 
-![Jedi_wc12](https://github.com/JCSDA-internal/roms-jedi/assets/23062912/7542473b-df3a-4495-a226-4a3006a92e6d)
+![Jedi_wc12](https://github.com/user-attachments/assets/c5886719-b83f-4e37-882f-01d3916fa5b4)
 
 The following instructions should have the steps needed to implement an interface capable of
 running any **`ROMS-JEDI`** application, as well as the available data assimilation drivers.

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -118,20 +118,20 @@ ecbuild_bundle_initialize()
 if( DEFINED ENV{jedi_cmake_ROOT} )
   include( $ENV{jedi_cmake_ROOT}/share/jedicmake/Functions/git_functions.cmake )
 else()
-  ecbuild_bundle( PROJECT jedicmake GIT "https://github.com/jcsda-internal/jedi-cmake.git" BRANCH develop UPDATE RECURSIVE )
+  ecbuild_bundle( PROJECT jedicmake GIT "https://github.com/jcsda/jedi-cmake.git" BRANCH develop UPDATE RECURSIVE )
   include( jedicmake/cmake/Functions/git_functions.cmake )
 endif()
 
 # Required repositories
 
- ecbuild_bundle( PROJECT roms       GIT "https://github.com/myroms/roms.git"                 BRANCH develop UPDATE )
- ecbuild_bundle( PROJECT oops       GIT "https://github.com/jcsda-internal/oops.git"         BRANCH develop UPDATE )
- ecbuild_bundle( PROJECT vader      GIT "https://github.com/jcsda-internal/vader.git"        BRANCH develop UPDATE )
- ecbuild_bundle( PROJECT saber      GIT "https://github.com/jcsda-internal/saber.git"        BRANCH develop UPDATE )
+ ecbuild_bundle( PROJECT roms       GIT "https://github.com/myroms/roms.git"        BRANCH develop UPDATE )
+ ecbuild_bundle( PROJECT oops       GIT "https://github.com/jcsda/oops.git"         BRANCH develop UPDATE )
+ ecbuild_bundle( PROJECT vader      GIT "https://github.com/jcsda/vader.git"        BRANCH develop UPDATE )
+ ecbuild_bundle( PROJECT saber      GIT "https://github.com/jcsda/saber.git"        BRANCH develop UPDATE )
 
- ecbuild_bundle( PROJECT gsw        GIT "https://github.com/jcsda-internal/GSW-Fortran.git"  BRANCH develop UPDATE )
- ecbuild_bundle( PROJECT ioda       GIT "https://github.com/jcsda-internal/ioda.git"         BRANCH develop UPDATE )
- ecbuild_bundle( PROJECT ufo        GIT "https://github.com/jcsda-internal/ufo.git"          BRANCH develop UPDATE )
+ ecbuild_bundle( PROJECT gsw        GIT "https://github.com/jcsda/GSW-Fortran.git"  BRANCH develop UPDATE )
+ ecbuild_bundle( PROJECT ioda       GIT "https://github.com/jcsda/ioda.git"         BRANCH develop UPDATE )
+ ecbuild_bundle( PROJECT ufo        GIT "https://github.com/jcsda/ufo.git"          BRANCH develop UPDATE )
 
  ecbuild_bundle( PROJECT roms-jedi  SOURCE ../ )
 


### PR DESCRIPTION
# Description

![roms-jedi_teal_300px](https://github.com/user-attachments/assets/b4f4cc66-bbf9-40db-87c5-df7ff085cf92)

We have been developing the **ROMS-JEDI** interface since 2021 and are now releasing it to the public as it is fully functional. This interface is designed for advanced users of data assimilation, the **ROMS** model, and the Joint Effort for Data Assimilation Integration (**JEDI**) framework. 

We do not have the time or resources to provide in-person training, tutorials, or community engagement. However, the Joint Center for Satellite Data Assimilation (**JCSDA**) has previously offered **JEDI** Academies, both in-person and online, to introduce and explain its technical components and how to apply them in various geophysical systems. A wealth of material, including videos, is available on the **JCSDA** [website](https://www.jcsda.org/jedi-academies). Please be aware that the system is quite complex and requires expertise to configure and run.

The **JEDI** framework is built upon the Object-Oriented Prediction System (**OOPS**), which was initially developed at **ECMWF** and further enhanced and supported by **JCSDA**. The **OOPS** infrastructure is a contemporary, abstract data assimilation framework designed using object-oriented programming principles and implemented in **C++**. Its robust template capabilities make it an effective tool for data assimilation tasks in any geophysical system without the need to develop such an algorithm technically separately for each model. 

The diagram below illustrates how the generic model-agnostic blocks interact with all **JEDI** components.

<img width="903" alt="image" src="https://github.com/user-attachments/assets/03d3e8dd-053d-4223-888a-421c1e86699e" />

Currently, we use **ROMS-JEDI** to examine various data assimilation algorithms, including variational (**3DVar**, **4DVar**, **3D-FGAT**/**4D-FGAT**), ensemble (**EDA**, **EnKF**, **LETKF**), and hybrid (**3DEnVar**/**4DEnVar**) methodologies.  For a technical description of these algorithms, please take a look at Bannister's excellent review (2017).

- Bennister, R.N., 2017: A review of operational methods of variational and ensemble-variational data assimilation, _Q. J. R. Meteorol. Soc._, **143**, 607-6333, [doi:10.1002/qj.2982](https://rmets.onlinelibrary.wiley.com/doi/10.1002/qj.2982).

## Impact 

With its public release, the **ROMS-JEDI** framework is now available to the community for scientific exploration, operational ocean forecasting, advanced courses on ocean estimation, and training the next generation of ocean prediction modelers. 

## Checklist

- [x] I have reviewed code updates or enhancements described in this PR
- [x] I have run and tested the changes before creating the PR

---

## ROMS-JEDI Unit Tests

All the available ROMS-JEDI Unit Tests are running successfully with the default **WC13** application:
```
Test project /home/arango/ocean/repository/git/myroms-jedi/build_public/roms-jedi
      Start  1: romsjedi_coding_norms
 1/52 Test  #1: romsjedi_coding_norms .............................   Passed    1.36 sec
      Start  2: test_romsjedi_geometry
 2/52 Test  #2: test_romsjedi_geometry ............................   Passed    0.68 sec
      Start  3: test_romsjedi_geometryiterator
 3/52 Test  #3: test_romsjedi_geometryiterator ....................   Passed    0.77 sec
      Start  4: test_romsjedi_state
 4/52 Test  #4: test_romsjedi_state ...............................   Passed    0.87 sec
      Start  5: test_romsjedi_increment
 5/52 Test  #5: test_romsjedi_increment ...........................   Passed    0.68 sec
      Start  6: test_romsjedi_model
 6/52 Test  #6: test_romsjedi_model ...............................   Passed   10.26 sec
      Start  7: test_romsjedi_linearmodel
 7/52 Test  #7: test_romsjedi_linearmodel .........................   Passed   17.95 sec
      Start  8: test_romsjedi_variableChange
 8/52 Test  #8: test_romsjedi_variableChange ......................   Passed    0.63 sec
      Start  9: test_romsjedi_hofx_3d
 9/52 Test  #9: test_romsjedi_hofx_3d .............................   Passed    0.85 sec
      Start 10: test_romsjedi_hofx_4d
10/52 Test #10: test_romsjedi_hofx_4d .............................   Passed   10.08 sec
      Start 11: test_romsjedi_makeobs
11/52 Test #11: test_romsjedi_makeobs .............................   Passed   10.15 sec
      Start 12: test_romsjedi_makeobs_perturbed
12/52 Test #12: test_romsjedi_makeobs_perturbed ...................   Passed   10.07 sec
      Start 13: test_romsjedi_diffstates
13/52 Test #13: test_romsjedi_diffstates ..........................   Passed    0.68 sec
      Start 14: test_romsjedi_forecast_roms
14/52 Test #14: test_romsjedi_forecast_roms .......................   Passed    4.74 sec
      Start 15: test_romsjedi_parameters_bump_cor_nicas
15/52 Test #15: test_romsjedi_parameters_bump_cor_nicas ...........   Passed  213.15 sec
      Start 16: test_romsjedi_parameters_bump_cor_nicas_max
16/52 Test #16: test_romsjedi_parameters_bump_cor_nicas_max .......   Passed   97.36 sec
      Start 17: test_romsjedi_parameters_diffusion
17/52 Test #17: test_romsjedi_parameters_diffusion ................   Passed  173.04 sec
      Start 18: test_romsjedi_parameters_bump_loc_cor_nicas
18/52 Test #18: test_romsjedi_parameters_bump_loc_cor_nicas .......   Passed   52.12 sec
      Start 19: test_romsjedi_parameters_bump_loc_cor_nicas_max
19/52 Test #19: test_romsjedi_parameters_bump_loc_cor_nicas_max ...   Passed   16.93 sec
      Start 20: test_romsjedi_dirac_cov_nicas
20/52 Test #20: test_romsjedi_dirac_cov_nicas .....................   Passed    1.50 sec
      Start 21: test_romsjedi_dirac_diffusion
21/52 Test #21: test_romsjedi_dirac_diffusion .....................   Passed    1.07 sec
      Start 22: test_romsjedi_ens_perturbation
22/52 Test #22: test_romsjedi_ens_perturbation ....................   Passed   36.38 sec
      Start 23: test_romsjedi_ens_meanandvariance
23/52 Test #23: test_romsjedi_ens_meanandvariance .................   Passed    0.79 sec
      Start 24: test_romsjedi_ens_recenter
24/52 Test #24: test_romsjedi_ens_recenter ........................   Passed    0.88 sec
      Start 25: test_romsjedi_ens_hofx
25/52 Test #25: test_romsjedi_ens_hofx ............................   Passed   10.83 sec
      Start 26: test_romsjedi_dirac_ens_cov_nicas
26/52 Test #26: test_romsjedi_dirac_ens_cov_nicas .................   Passed    1.92 sec
      Start 27: test_romsjedi_3dvar_zeroObs
27/52 Test #27: test_romsjedi_3dvar_zeroObs .......................   Passed    1.48 sec
      Start 28: test_romsjedi_3dvar_singleObs
28/52 Test #28: test_romsjedi_3dvar_singleObs .....................   Passed    1.93 sec
      Start 29: test_romsjedi_3dvar_primal
29/52 Test #29: test_romsjedi_3dvar_primal ........................   Passed    2.62 sec
      Start 30: test_romsjedi_3dvar_dual
30/52 Test #30: test_romsjedi_3dvar_dual ..........................   Passed    2.45 sec
      Start 31: test_romsjedi_3dfgat_singleObs
31/52 Test #31: test_romsjedi_3dfgat_singleObs ....................   Passed   13.55 sec
      Start 32: test_romsjedi_3dfgat_primal
32/52 Test #32: test_romsjedi_3dfgat_primal .......................   Passed   13.33 sec
      Start 33: test_romsjedi_3dfgat_dual
33/52 Test #33: test_romsjedi_3dfgat_dual .........................   Passed   13.12 sec
      Start 34: test_romsjedi_4dfgat_singleObs
34/52 Test #34: test_romsjedi_4dfgat_singleObs ....................   Passed   24.31 sec
      Start 35: test_romsjedi_4dfgat_primal
35/52 Test #35: test_romsjedi_4dfgat_primal .......................   Passed   38.39 sec
      Start 36: test_romsjedi_4dfgat_dual
36/52 Test #36: test_romsjedi_4dfgat_dual .........................   Passed   34.66 sec
      Start 37: test_romsjedi_4dvar_singleObs_bump
37/52 Test #37: test_romsjedi_4dvar_singleObs_bump ................   Passed   47.56 sec
      Start 38: test_romsjedi_4dvar_singleObs_diffusion
38/52 Test #38: test_romsjedi_4dvar_singleObs_diffusion ...........   Passed   47.25 sec
      Start 39: test_romsjedi_4dvar_bump
39/52 Test #39: test_romsjedi_4dvar_bump ..........................   Passed  274.51 sec
      Start 40: test_romsjedi_4dvar_diffusion
40/52 Test #40: test_romsjedi_4dvar_diffusion .....................   Passed  273.40 sec
      Start 41: test_romsjedi_3denvar_nofgat_primal
41/52 Test #41: test_romsjedi_3denvar_nofgat_primal ...............   Passed    3.55 sec
      Start 42: test_romsjedi_3denvar_nofgat_dual
42/52 Test #42: test_romsjedi_3denvar_nofgat_dual .................   Passed    3.32 sec
      Start 43: test_romsjedi_3denvar_4dfgat_primal
43/52 Test #43: test_romsjedi_3denvar_4dfgat_primal ...............   Passed   39.80 sec
      Start 44: test_romsjedi_3denvar_4dfgat_dual
44/52 Test #44: test_romsjedi_3denvar_4dfgat_dual .................   Passed   35.76 sec
      Start 45: test_romsjedi_3dhyb_nofgat_primal
45/52 Test #45: test_romsjedi_3dhyb_nofgat_primal .................   Passed    4.39 sec
      Start 46: test_romsjedi_3dhyb_nofgat_dual
46/52 Test #46: test_romsjedi_3dhyb_nofgat_dual ...................   Passed    4.26 sec
      Start 47: test_romsjedi_3dhyb_4dfgat_primal
47/52 Test #47: test_romsjedi_3dhyb_4dfgat_primal .................   Passed   40.43 sec
      Start 48: test_romsjedi_3dhyb_4dfgat_dual
48/52 Test #48: test_romsjedi_3dhyb_4dfgat_dual ...................   Passed   37.19 sec
      Start 49: test_romsjedi_letkf_solver
49/52 Test #49: test_romsjedi_letkf_solver ........................   Passed    2.37 sec
      Start 50: test_romsjedi_letkf_splitObserver
50/52 Test #50: test_romsjedi_letkf_splitObserver .................   Passed    1.21 sec
      Start 51: test_romsjedi_letkf_splitSolver
51/52 Test #51: test_romsjedi_letkf_splitSolver ...................   Passed    1.33 sec
      Start 52: test_romsjedi_letkf_3dhyb
52/52 Test #52: test_romsjedi_letkf_3dhyb .........................   Passed   37.43 sec

100% tests passed, 0 tests failed out of 52

Label Time Summary:
executable    =  31.84 sec*proc (7 tests)
mpi           = 1673.98 sec*proc (51 tests)
roms-jedi     = 1675.34 sec*proc (52 tests)
script        = 1643.50 sec*proc (45 tests)

Total Test time (real) = 1675.58 sec
```